### PR TITLE
fix: incorrect assignment to invalid parameter

### DIFF
--- a/addons/paulloz.colorblindness/colorblindness.gd
+++ b/addons/paulloz.colorblindness/colorblindness.gd
@@ -32,4 +32,4 @@ func _ready():
 	self.get_tree().root.size_changed.connect(_on_viewport_size_changed)
 
 func _on_viewport_size_changed():
-	self.rect.rect_min_size = self.rect.get_viewport_rect().size
+	self.rect.custom_minimum_size = self.rect.get_viewport_rect().size


### PR DESCRIPTION
Just installed this plugin on 4.6 (version on the asset lib needs to be updated btw, still listed as only compatible with 3.x)

Seemed to work perfectly fine, minus this one issue I found